### PR TITLE
Implementação de paginação

### DIFF
--- a/src/main/java/com/github/apoioSolidario/web/controller/CampaignController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/CampaignController.java
@@ -4,8 +4,10 @@ import com.github.apoioSolidario.domain.dto.request.CampaignRequest;
 import com.github.apoioSolidario.domain.dto.request.UpdateStatusRequest;
 import com.github.apoioSolidario.domain.dto.response.CampaignResponse;
 import com.github.apoioSolidario.domain.dto.response.EventResponse;
+import com.github.apoioSolidario.domain.model.Campaign;
 import com.github.apoioSolidario.services.CampaignService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -28,19 +31,23 @@ import java.util.List;
 public class CampaignController {
 
     private final CampaignService service;
+    private final ResponseUtils responseUtils;
 
-    public CampaignController(CampaignService service) {
+    public CampaignController(CampaignService service, ResponseUtils responseUtils) {
         this.service = service;
+        this.responseUtils = responseUtils;
     }
-
 
     @Operation(summary = "Recuperar todas as campanhas")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Todas as campanhas recuperadas com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<CampaignResponse>> getAllCampaigns(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
+    public ResponseEntity<List<CampaignResponse>> getAllCampaigns(Pageable pageable) {
+        Page<CampaignResponse> campanhas = service.findAll(pageable);
+        List<CampaignResponse> campanhasResponse = campanhas.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(campanhas);
+        return ResponseEntity.ok().headers(headers).body(campanhasResponse);
     }
 
     @Operation(summary = "Recuperar uma campanha específica pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/EventController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/EventController.java
@@ -2,9 +2,11 @@ package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.EventRequest;
 import com.github.apoioSolidario.domain.dto.request.UpdateStatusRequest;
+import com.github.apoioSolidario.domain.dto.response.CampaignResponse;
 import com.github.apoioSolidario.domain.dto.response.EventResponse;
 import com.github.apoioSolidario.services.EventService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -24,9 +27,11 @@ import java.util.List;
 @RequestMapping("/events")
 public class EventController {
     private final EventService service;
+    private final ResponseUtils responseUtils;
 
-    public EventController(EventService eventService) {
-        this.service = eventService;
+    public EventController(EventService service, ResponseUtils responseUtils) {
+        this.service = service;
+        this.responseUtils = responseUtils;
     }
 
     @Operation(summary = "Recuperar todos os eventos")
@@ -34,8 +39,11 @@ public class EventController {
             @ApiResponse(responseCode = "200", description = "Todos os eventos recuperados com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<EventResponse>> getAllEvents(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
+    public ResponseEntity<List<EventResponse>> getAllEvents(Pageable pageable) {
+        Page<EventResponse> events = service.findAll(pageable);
+        List<EventResponse> eventResponses = events.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(events);
+        return ResponseEntity.ok().headers(headers).body(eventResponses);
     }
 
     @Operation(summary = "Recuperar um evento específico pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/FeedbackController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/FeedbackController.java
@@ -1,9 +1,11 @@
 package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.FeedbackRequest;
+import com.github.apoioSolidario.domain.dto.response.EventResponse;
 import com.github.apoioSolidario.domain.dto.response.FeedbackResponse;
 import com.github.apoioSolidario.services.FeedbackService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -24,9 +27,11 @@ import java.util.List;
 @RequestMapping("/feedbacks")
 public class FeedbackController {
     private final FeedbackService service;
+    private final ResponseUtils responseUtils;
 
-    public FeedbackController(FeedbackService service) {
+    public FeedbackController(FeedbackService service, ResponseUtils responseUtils) {
         this.service = service;
+        this.responseUtils = responseUtils;
     }
 
     @Operation(summary = "Recuperar todos os feedbacks")
@@ -34,8 +39,11 @@ public class FeedbackController {
             @ApiResponse(responseCode = "200", description = "Todos os feedbacks recuperados com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<FeedbackResponse>> getAllFeedbacks(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
+    public ResponseEntity<List<FeedbackResponse>> getAllFeedbacks(Pageable pageable) {
+        Page<FeedbackResponse> feedbacks = service.findAll(pageable);
+        List<FeedbackResponse> feedbackResponses = feedbacks.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(feedbacks);
+        return ResponseEntity.ok().headers(headers).body(feedbackResponses);
     }
 
     @Operation(summary = "Recuperar um feedback específico pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/ImageController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/ImageController.java
@@ -1,9 +1,11 @@
 package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.ImageRequest;
+import com.github.apoioSolidario.domain.dto.response.FeedbackResponse;
 import com.github.apoioSolidario.domain.dto.response.ImageResponse;
 import com.github.apoioSolidario.services.ImageService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,20 +15,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @Tag(name = "Imagens", description = "Contém todos os métodos relacionados a imagens.")@RestController
 @RequestMapping("/images")
 public class ImageController {
     
     private final ImageService service;
+    private final ResponseUtils responseUtils;
 
-    public ImageController(ImageService service) {
+    public ImageController(ImageService service, ResponseUtils responseUtils) {
         this.service = service;
+        this.responseUtils = responseUtils;
     }
 
     @Operation(summary = "Recuperar todas as imagens")
@@ -34,8 +40,11 @@ public class ImageController {
             @ApiResponse(responseCode = "200", description = "Todas as imagens recuperadas com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<ImageResponse>> getAllImages(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
+    public ResponseEntity<List<ImageResponse>> getAllImages(Pageable pageable) {
+        Page<ImageResponse> images = service.findAll(pageable);
+        List<ImageResponse> imageResponses = images.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(images);
+        return ResponseEntity.ok().headers(headers).body(imageResponses);
     }
 
     @Operation(summary = "Recuperar uma imagem específica pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/LocationController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/LocationController.java
@@ -2,10 +2,12 @@ package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.LocationRequest;
 import com.github.apoioSolidario.domain.dto.request.OngRequest;
+import com.github.apoioSolidario.domain.dto.response.ImageResponse;
 import com.github.apoioSolidario.domain.dto.response.LocationResponse;
 import com.github.apoioSolidario.domain.dto.response.OngResponse;
 import com.github.apoioSolidario.services.LocationService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -27,19 +30,23 @@ import java.util.List;
 public class LocationController {
 
     private final LocationService service;
+    private final ResponseUtils responseUtils;
 
-    public LocationController(LocationService service) {
+    public LocationController(LocationService service, ResponseUtils responseUtils) {
         this.service = service;
+        this.responseUtils = responseUtils;
     }
-
 
     @Operation(summary = "Recuperar todos os locais")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Todos os locais recuperados com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<LocationResponse>> getAllLocations(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
+    public ResponseEntity<List<LocationResponse>> getAllLocations(Pageable pageable) {
+        Page<LocationResponse> locations = service.findAll(pageable);
+        List<LocationResponse> locationResponses = locations.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(locations);
+       return ResponseEntity.ok().headers(headers).body(locationResponses);
     }
 
     @Operation(summary = "Recuperar um local específico pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/OngController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/OngController.java
@@ -2,10 +2,12 @@ package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.OngRequest;
 import com.github.apoioSolidario.domain.dto.request.UpdateStatusRequest;
+import com.github.apoioSolidario.domain.dto.response.LocationResponse;
 import com.github.apoioSolidario.domain.dto.response.OngResponse;
 import com.github.apoioSolidario.domain.model.Ong;
 import com.github.apoioSolidario.services.OngService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,6 +19,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -27,16 +30,21 @@ import java.util.List;
 @RequestMapping("/ongs")
 public class OngController {
     private final OngService ongService;
+    private final ResponseUtils responseUtils;
 
-    public OngController(OngService ongService) {
+    public OngController(OngService ongService, ResponseUtils responseUtils) {
         this.ongService = ongService;
+        this.responseUtils = responseUtils;
     }
 
     @Operation(summary = "Recuperar todas as organizações")
     @ApiResponse(responseCode = "200", description = "Recurso encontrado com sucesso")
     @GetMapping
-    public ResponseEntity<Page<OngResponse>> getAllOngs(Pageable pageable) {
-        return ResponseEntity.ok().body(ongService.findAll(pageable));
+    public ResponseEntity<List<OngResponse>> getAllOngs(Pageable pageable) {
+        Page<OngResponse> ongs = ongService.findAll(pageable);
+        List<OngResponse> ongResponses = ongs.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(ongs);
+        return ResponseEntity.ok().headers(headers).body(ongResponses);
     }
 
     @Operation(summary = "Recuperar uma organização pelo ID")

--- a/src/main/java/com/github/apoioSolidario/web/controller/OngSocialController.java
+++ b/src/main/java/com/github/apoioSolidario/web/controller/OngSocialController.java
@@ -1,9 +1,11 @@
 package com.github.apoioSolidario.web.controller;
 
 import com.github.apoioSolidario.domain.dto.request.OngSocialRequest;
+import com.github.apoioSolidario.domain.dto.response.OngResponse;
 import com.github.apoioSolidario.domain.dto.response.OngSocialResponse;
 import com.github.apoioSolidario.services.OngSocialService;
 import com.github.apoioSolidario.web.exception.ErrorMessage;
+import com.github.apoioSolidario.web.utils.ResponseUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -26,9 +29,11 @@ import java.util.List;
 public class OngSocialController {
 
     private final OngSocialService service;
+    private final ResponseUtils responseUtils;
 
-    public OngSocialController(OngSocialService service) {
+    public OngSocialController(OngSocialService service, ResponseUtils responseUtils) {
         this.service = service;
+        this.responseUtils = responseUtils;
     }
 
     @Operation(summary = "Recuperar todas as redes sociais de ONGs")
@@ -36,9 +41,11 @@ public class OngSocialController {
             @ApiResponse(responseCode = "200", description = "Todas as redes sociais de ONGs recuperadas com sucesso")
     })
     @GetMapping
-    public ResponseEntity<Page<OngSocialResponse>> getAllOngSocials(Pageable pageable) {
-        return ResponseEntity.ok().body(service.findAll(pageable));
-    }
+    public ResponseEntity<List<OngSocialResponse>> getAllOngSocials(Pageable pageable) {
+        Page<OngSocialResponse> ongSocials = service.findAll(pageable);
+        List<OngSocialResponse> ongSocialResponses = ongSocials.getContent();
+        HttpHeaders headers = responseUtils.getHeaders(ongSocials);
+        return ResponseEntity.ok().headers(headers).body(ongSocialResponses);    }
 
     @Operation(summary = "Recuperar uma rede social específica de ONG pelo ID")
     @ApiResponses(value = {

--- a/src/main/java/com/github/apoioSolidario/web/utils/ResponseUtils.java
+++ b/src/main/java/com/github/apoioSolidario/web/utils/ResponseUtils.java
@@ -1,0 +1,24 @@
+package com.github.apoioSolidario.web.utils;
+
+import com.github.apoioSolidario.domain.dto.response.CampaignResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ResponseUtils {
+
+    public<T> HttpHeaders getHeaders(Page<T> page) {
+        HttpHeaders headers = new HttpHeaders() {{
+            // We add +1 because of 'one-indexed-parameters' is set to true
+            add("X-Pagination-Page-Index", String.valueOf(page.getNumber() + 1));
+            add("X-Pagination-Page-Size", String.valueOf(page.getNumberOfElements()));
+            add("X-Pagination-Page-Total", String.valueOf(page.getTotalPages()));
+            add("X-Pagination-Item-Total", String.valueOf(page.getTotalElements()));
+        }};
+
+        headers.add("Content-Language", "pt-br");
+
+        return headers;
+    }
+}


### PR DESCRIPTION
- Implementação de paginação nos controladores:

  Adicionada a funcionalidade de paginação em todos os controladores da API. Agora, todos os endpoints que retornam listas de recursos suportam paginação através dos parâmetros page, size e sort.

- Criação do ResponseUtils:

  Foi criado um utilitário chamado ResponseUtils, responsável por converter as páginas (Page) retornadas pelo Spring em listas (List), além de adicionar os dados de paginação no cabeçalho da resposta HTTP. Isso inclui informações como o número total de páginas, número total de itens e o tamanho da página atual.